### PR TITLE
#16: remove zero in polynomial add and times

### DIFF
--- a/pymwp/polynomial.py
+++ b/pymwp/polynomial.py
@@ -190,7 +190,7 @@ class Polynomial:
                 j = j + 1
 
         sorted_monomials = Polynomial.sort_monomials(new_list)
-        return Polynomial(sorted_monomials)
+        return Polynomial(sorted_monomials).remove_zeros()
 
     def times(self, polynomial: Polynomial) -> Polynomial:
         """Multiply two polynomials.
@@ -293,7 +293,7 @@ class Polynomial:
                     index_list.append(smallest)
             # 7. repeat until done
 
-        return Polynomial(result)
+        return Polynomial(result).remove_zeros()
 
     def eval(self, argument_list: list[int]) -> str:
         """Evaluate polynomial.
@@ -477,3 +477,26 @@ class Polynomial:
         # doesn't matter; just append whatever
         # remains of left or right tail
         return new_list + right + left
+
+    def remove_zeros(self) -> Polynomial:
+        """Removes all encountered 0s from a polynomial.
+
+        Before returning, if the list is empty, the result produces a
+            0-monomial.
+
+        Arguments:
+            polynomial: from which to remove zeros
+
+        Returns:
+            polynomial with list of monomials for which zeros are
+            removed, unless 0 is the only monomial.
+        """
+        filtered_monomials = list(filter(
+            lambda mono: mono.scalar != ZERO_MWP, self.list))
+
+        if len(filtered_monomials) == 0:
+            self.list = [Monomial(ZERO_MWP)]
+        else:
+            self.list = filtered_monomials
+
+        return self

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -46,10 +46,9 @@ def test_analyze_simple_non_infinite(mocker):
     assert combinations == [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2],
                             [2, 0], [2, 1], [2, 2]]
     assert relation.variables == ['X0', 'X1']
-    assert str(relation.matrix[0][0].list[0]) == 'o'
-    assert str(relation.matrix[0][0].list[1]) == 'w.delta(0,0)'
-    assert str(relation.matrix[0][0].list[2]) == 'w.delta(1,0)'
-    assert str(relation.matrix[0][0].list[3]) == 'w.delta(2,0)'
+    assert str(relation.matrix[0][0].list[0]) == 'w.delta(0,0)'
+    assert str(relation.matrix[0][0].list[1]) == 'w.delta(1,0)'
+    assert str(relation.matrix[0][0].list[2]) == 'w.delta(2,0)'
 
 
 def test_analyze_if_with_braces(mocker):
@@ -57,7 +56,8 @@ def test_analyze_if_with_braces(mocker):
                  return_value=IF_WITH_BRACES)
     relation, combinations = Analysis.run("if_braces", no_save=True)
 
-    assert combinations == [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]]
+    assert combinations == [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2],
+                            [2, 0], [2, 1], [2, 2]]
     assert relation.variables == ['x', 'x1', 'x2', 'x3', 'y']
     # Should we have `m` on diag for x3 ? don't think so
     # since X3 is constant in all cases…
@@ -68,6 +68,7 @@ def test_analyze_if_with_braces(mocker):
     except AssertionError:
         relation.show()
         raise
+
 
 def test_analyze_if_without_braces(mocker):
     mocker.patch('pymwp.analysis.Analysis.parse_c_file',
@@ -75,7 +76,8 @@ def test_analyze_if_without_braces(mocker):
     relation, combinations = Analysis.run("if_wo_braces", no_save=True)
 
     # should have exact same result as previous test...
-    assert combinations == [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]]
+    assert combinations == [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2],
+                            [2, 0], [2, 1], [2, 2]]
     assert relation.variables == ['x', 'x1', 'x2', 'x3', 'y']
     # Should we have `m` on diag for x3 ? don't think so
     # since X3 is constant in all cases…
@@ -87,24 +89,26 @@ def test_analyze_if_without_braces(mocker):
         relation.show()
         raise
 
+
 def test_analyze_variable_ignore(mocker):
     mocker.patch('pymwp.analysis.Analysis.parse_c_file',
                  return_value=VARIABLE_IGNORED)
     relation, combinations = Analysis.run("variable_ignored", no_save=True)
 
-    assert combinations == [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]]
+    assert combinations == [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2],
+                            [2, 0], [2, 1], [2, 2]]
     assert relation.variables == ['X2', 'X3', 'X1', 'X4']
 
-    wmp = '+o+w.delta(0,0)+m.delta(1,0)+p.delta(2,0)'
-    wpm = '+o+w.delta(0,0)+p.delta(1,0)+m.delta(2,0)'
+    wmp = '+w.delta(0,0)+m.delta(1,0)+p.delta(2,0)'
+    wpm = '+w.delta(0,0)+p.delta(1,0)+m.delta(2,0)'
     o = '+o'
     m = '+m'
     res = [
-        [o,o,o,o],
-        [wmp,m,o,wmp],
-        [wpm,o,m,wpm],
-        [o,o,o,o],
-        ]
+        [o, o, o, o],
+        [wmp, m, o, wmp],
+        [wpm, o, m, wpm],
+        [o, o, o, o],
+    ]
 
     try:
         for i in range(len(relation.variables)):

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -118,3 +118,40 @@ def test_polynomial_sort_2():
     assert p[1].deltas == [(1, 1), (1, 2)]
     assert p[2].deltas == [(1, 2), (1, 3)]
     assert p[3].deltas == [(1, 4)]
+
+
+def test_polynomial_remove_zeros_with_deltas():
+    # see: https://github.com/seiller/pymwp/issues/16
+    zero = Polynomial([Monomial('o')])
+    poly = Polynomial([Monomial('m', [(0, 0), (1, 1)])])
+
+    after_add = zero + poly
+    after_add.remove_zeros()
+    scalars_after_add = [mono.scalar for mono in after_add.list]
+
+    assert 'o' not in scalars_after_add
+    assert 'm' in scalars_after_add
+
+
+def test_polynomial_remove_zeros_no_deltas():
+    zero = Polynomial([Monomial('o')])
+    poly = Polynomial([Monomial('w')])
+
+    # add two when there are no deltas
+    after_add = zero + poly
+    after_add.remove_zeros()
+    scalars_after_add = [mono.scalar for mono in after_add.list]
+
+    # w-monomial remains
+    assert len(after_add.list) == 1
+    assert 'o' not in scalars_after_add
+    assert 'w' in scalars_after_add
+
+
+def test_polynomial_remove_zeros_empty():
+    # only 0-monomials
+    poly = Polynomial([Monomial('o'), Monomial('o'), Monomial('o')])
+    poly.remove_zeros()
+    # exactly 1 remains after
+    assert len(poly.list) == 1
+    assert poly.list[0].scalar == 'o'


### PR DESCRIPTION
see issue #16 

Added some notes on why some tests change. IDE added some whitespace. 

Beyond that, this changeset includes the following:

- 1 new method (`Polynomial.remove_zeros`)
- unit tests for that method
- `remove_zeros` is applied to polynomial `add` and `times`.
